### PR TITLE
fix: disable index presenter shortcut

### DIFF
--- a/src/TheNoteTaker-UI/NTSpNoteIndexPresenter.class.st
+++ b/src/TheNoteTaker-UI/NTSpNoteIndexPresenter.class.st
@@ -151,13 +151,13 @@ NTSpNoteIndexPresenter >> initializePresenters [
 		beMultipleSelection;
 		sortingBlock: [ :a :b |
 			a note modificationDate > b note modificationDate ];
-		addShortcutWith: [ :action |
+		"addShortcutWith: [ :action |
 				action
 					shortcutKey: KeyboardKey delete asKeyCombination;
 					action: [
 							NTSpRemoveNoteCommand new
 								context: self;
-								execute ] ];
+								execute ] ];"
 		contextMenu: [
 				(self rootCommandsGroup / 'NTSelContextualMenu') beRoot
 					asMenuPresenter ]


### PR DESCRIPTION
I just comment the shortcut in indexPresenter.
It seems the problem come from the Morphic Adapter, he didn't accept both contextMenu and shortcut for a presenter, maybe the problem didn't exist in toplo ?

Should Fixes #114